### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,18 +10,18 @@
 # Methods and Functions (KEYWORD1)
 #######################################
 
-begin         KEYWORD1
-write         KEYWORD1
-setOvervoltage         KEYWORD1
-setThermal         KEYWORD1
-enableOpenload         KEYWORD1
-loadDetect         KEYWORD1
+begin	KEYWORD1
+write	KEYWORD1
+setOvervoltage	KEYWORD1
+setThermal	KEYWORD1
+enableOpenload	KEYWORD1
+loadDetect	KEYWORD1
 
 #######################################
 # Instances (KEYWORD2)
 #######################################
 
-MC33996         KEYWORD2
+MC33996	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords